### PR TITLE
Change max audio channels setting to a string

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -2,3 +2,4 @@ node_modules
 # Keep environment variables out of version control
 .env
 out/
+temp/

--- a/server/dao/settings.ts
+++ b/server/dao/settings.ts
@@ -158,7 +158,7 @@ export type PlexStreamSettings = {
   maxTranscodeResolution: Resolution;
   videoCodecs: string[];
   audioCodecs: string[];
-  maxAudioChannels: number;
+  maxAudioChannels: string;
   audioBoost: number;
   enableSubtitles: boolean;
   subtitleSize: number;

--- a/types/src/schemas/settingsSchemas.ts
+++ b/types/src/schemas/settingsSchemas.ts
@@ -90,7 +90,7 @@ export const PlexStreamSettingsSchema = z.object({
     .array(z.string())
     .default(['h264', 'hevc', 'mpeg2video', 'av1']),
   audioCodecs: z.array(z.string()).default(['ac3']),
-  maxAudioChannels: z.number().default(2),
+  maxAudioChannels: z.string().default('2.0'),
   audioBoost: z.number().default(100),
   enableSubtitles: z.boolean().default(false),
   subtitleSize: z.number().default(100),


### PR DESCRIPTION
Turns out the legacy DB stored this as an ID to a value on the frontend (e.g. 3 => "2.1"). We're just going to store the raw string of the actual audio channel value.

I haven't hooked up a framework for new DB migrations, so this will require a manual migration of the settings.json file for the new value.

### Explanation of the changes, problem that they are intended to fix.
